### PR TITLE
submix where not correctly set in Levels

### DIFF
--- a/goxlr/types/models.py
+++ b/goxlr/types/models.py
@@ -259,7 +259,7 @@ class Levels:
         self.output_monitor = OutputDevice[levels.get("output_monitor")]
         self.volumes = {Channel[k]: v for k, v in levels.get("volumes").items()}
         if submix := levels.get("submix"):
-            self.submix = {Channel[k]: v for k, v in submix.items()}
+            self.submix = Submixes(submix)
         else:
             self.submix = None
         self.bleep = levels.get("bleep")


### PR DESCRIPTION
setting Levels.submix did not use Submixes dataclass and was throwing a KeyError: 'inputs'
